### PR TITLE
chore(docs): update readme commands 📑

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,9 +21,12 @@ see how to [contribute](contributing.md)
 git clone https://github.com/moncke/ko6a
 cd ko6a
 yarn
-yarn dev
 ```
 
 create a `.env.local` file similar to [`.env.example`](./.env.example)
 
 expects a github [personal access token](https://github.com/settings/tokens) with `repo` access
+
+```bash
+yarn dev
+```


### PR DESCRIPTION
moved the `yarn dev` command to appear after the instructions to create a local environment file and github token for clarity